### PR TITLE
Update outdated dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "fs-jetpack": "^0.9.0",
     "mime": "^1.3.4",
-    "pdfjs-dist": "1.5.426",
-    "receipt-scanner": "^0.1.0",
+    "pdfjs-dist": "1.5.500",
+    "receipt-scanner": "^0.3.0",
     "tmp": "^0.0.29",
-    "vue": "^1.0.25"
+    "vue": "^1.0.28"
   },
   "packageNameTemplate": "{{name}}-v{{version}}-{{platform}}-{{arch}}",
   "osx": {

--- a/package.json
+++ b/package.json
@@ -37,23 +37,24 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "electron": "1.3.3",
-    "electron-builder": "^5.12.1",
+    "electron": "^1.4.2",
+    "electron-builder": "^7.9.0",
     "electron-mocha": "^3.0.0",
     "fs-jetpack": "^0.9.0",
     "gulp": "^3.9.0",
     "gulp-batch": "^1.0.5",
+    "gulp-exec": "^2.1.2",
     "gulp-less": "^3.0.3",
     "gulp-plumber": "^1.1.0",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.5",
     "istanbul": "^0.4.3",
     "mocha": "^3.0.2",
-    "rollup": "^0.35.12",
-    "rollup-plugin-istanbul": "1.0.0",
+    "rollup": "^0.36.1",
+    "rollup-plugin-istanbul": "1.1.0",
     "sinon": "^1.17.5",
     "source-map-support": "^0.4.2",
     "spectron": "^3.3.0",
-    "yargs": "^4.2.0"
+    "yargs": "^6.0.0"
   }
 }


### PR DESCRIPTION
Updating some dependencies. Vue has been upgraded to 2.0, but it requires a overhaul of the existing code.
